### PR TITLE
Modify temp copy of LinkedList

### DIFF
--- a/Assets/_Project/Scripts/AudioSystem/SoundManager.cs
+++ b/Assets/_Project/Scripts/AudioSystem/SoundManager.cs
@@ -44,7 +44,10 @@ namespace AudioSystem {
         }
 
         public void StopAll() {
-            foreach (var soundEmitter in activeSoundEmitters) {
+			LinkedList<SoundEmitter> tempList = new LinkedList<SoundEmitter>(activeSoundEmitters);
+
+			foreach (var soundEmitter in tempList)
+            {
                 soundEmitter.Stop();
             }
 


### PR DESCRIPTION
Fixes an issue where a LinkedList is modified in a foreach loop, causing the following error. Error is removed when iterating over a copy of `activeSoundEmitters`.

```
InvalidOperationException: Collection was modified; enumeration operation may not execute.
System.Collections.Generic.List`1+Enumerator[T].MoveNextRare () (at <fd98429b8c6c4f82ba907b21c76e6375>:0)
System.Collections.Generic.List`1+Enumerator[T].MoveNext () (at <fd98429b8c6c4f82ba907b21c76e6375>:0)
AudioSystem.SoundManager.StopAll () (at Assets/_Project/Scripts/AudioTest/AudioSystem/SoundManager.cs:92)
PatternManager.ResetsForNewGame () (at Assets/_Project/Scripts/ManualPatterns/PatternManagers/PatternManager.cs:157)
PatternManager.OnPlayButton () (at Assets/_Project/Scripts/ManualPatterns/PatternManagers/PatternManager.cs:113)
System.Runtime.CompilerServices.AsyncMethodBuilderCore+<>c.<ThrowAsync>b__7_0 (System.Object state) (at <fd98429b8c6c4f82ba907b21c76e6375>:0)
UnityEngine.UnitySynchronizationContext+WorkRequest.Invoke () (at /Users/bokken/build/output/unity/unity/Runtime/Export/Scripting/UnitySynchronizationContext.cs:156)
UnityEngine.UnitySynchronizationContext.Exec () (at /Users/bokken/build/output/unity/unity/Runtime/Export/Scripting/UnitySynchronizationContext.cs:84)
UnityEngine.UnitySynchronizationContext.ExecuteTasks () (at /Users/bokken/build/output/unity/unity/Runtime/Export/Scripting/UnitySynchronizationContext.cs:110)
```

From Google AI...

> Reason for the Error: When you use a foreach loop or an enumerator to traverse a collection like a LinkedList, the enumerator maintains an internal state to keep track of its position within the collection. If the collection is modified (e.g., elements are added, removed, or the order changes) while the enumeration is in progress, the enumerator's internal state becomes invalid, leading to the InvalidOperationException. Solutions: Iterate Over a Copy.

